### PR TITLE
feat: users-follow 연관 관계 구현

### DIFF
--- a/src/main/java/com/example/spartanewsfeed/user/entity/User.java
+++ b/src/main/java/com/example/spartanewsfeed/user/entity/User.java
@@ -1,9 +1,13 @@
 package com.example.spartanewsfeed.user.entity;
 
 import com.example.spartanewsfeed.common.entity.BaseEntity;
+import com.example.spartanewsfeed.follow.entity.Follow;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -24,6 +28,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Follow> followers = new HashSet<>();
+
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Follow> following = new HashSet<>();
+
     private boolean isPublic;
 
     public User(String email, String name, String password, boolean isPublic){
@@ -38,6 +48,14 @@ public class User extends BaseEntity {
         this.name = name;
         this.password = password;
         this.isPublic = isPublic;
+    }
+
+    public void addFollower(Follow follow){
+        this.followers.add(follow);
+    }
+
+    public void addFollowing(Follow follow){
+        this.following.add(follow);
     }
 
 }


### PR DESCRIPTION
## 작업 내용
User 엔티티에 follow 관계를 위한 양방향 연관 관계 컬렉션 필드를 추가했습니다.
followers, following 컬렉션 필드를 추가했고,
@OneToMany 어노테이션을 사용하여 Follow 엔티티의 follower, following 필드와 매핑했습니다.

## 변경 목적
User 객체에서 해당 유저를 팔로우하는 목록과 팔로잉하는 목록을 직접 조회할 수 있도록 하여 코드 가독성을 높였습니다