### PR TITLE
feat: 세션 인증을 적용하여 팔로우 기능 보안 강화 및 dto 수정

### DIFF
--- a/src/main/java/com/example/spartanewsfeed/follow/controller/FollowController.java
+++ b/src/main/java/com/example/spartanewsfeed/follow/controller/FollowController.java
@@ -1,48 +1,40 @@
 package com.example.spartanewsfeed.follow.controller;
 
 import com.example.spartanewsfeed.follow.service.FollowService;
-import com.example.spartanewsfeed.follow.dto.request.FollowRequestDto;
-import com.example.spartanewsfeed.user.entity.User;
+import com.example.spartanewsfeed.follow.dto.response.FollowResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import com.example.spartanewsfeed.user.repository.UserRepository;
 
 @RestController
-@RequestMapping("/users/{userId}")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class FollowController {
 
     private final FollowService followService;
-    private final UserRepository userRepository;
 
-    @PostMapping("/follow")
-    public ResponseEntity<String> follow(@PathVariable Long userId, @RequestBody FollowRequestDto requestDto) {
+    @PostMapping("/{followingId}/follow")
+    public ResponseEntity<FollowResponse> follow(@PathVariable Long followingId, HttpServletRequest request) {
         try {
-            User follower = userRepository.findById(userId).orElseThrow(
-                    () -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-            User following = userRepository.findById(requestDto.getFollowingId()).orElseThrow(
-                    () -> new IllegalArgumentException("팔로우 대상을 찾을 수 없습니다."));
-            followService.followUser(follower, following);
+            Long followerId = (Long) request.getSession(false).getAttribute("sessionKey");
 
-            return ResponseEntity.ok("팔로우했습니다.");
+            followService.followUser(followerId, followingId);
+            return ResponseEntity.ok(new FollowResponse("팔로우했습니다."));
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            return ResponseEntity.badRequest().body(new FollowResponse(e.getMessage()));
         }
     }
 
-    @DeleteMapping("/follow")
-    public ResponseEntity<String> unfollow(@PathVariable Long userId, @RequestBody FollowRequestDto requestDto) {
+    @DeleteMapping("/{followingId}/follow")
+    public ResponseEntity<FollowResponse> unfollow(@PathVariable Long followingId, HttpServletRequest request) {
         try {
-            User follower = userRepository.findById(userId).orElseThrow(
-                    () -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-            User following = userRepository.findById(requestDto.getFollowingId()).orElseThrow(
-                    () -> new IllegalArgumentException("언팔로우 대상을 찾을 수 없습니다."));
-            followService.unfollowUser(follower, following);
+            Long followerId = (Long) request.getSession(false).getAttribute("sessionKey");
 
-            return ResponseEntity.ok("언팔로우됐습니다.");
+            followService.unfollowUser(followerId, followingId);
+            return ResponseEntity.ok(new FollowResponse("언팔로우됐습니다."));
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            return ResponseEntity.badRequest().body(new FollowResponse(e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/example/spartanewsfeed/follow/dto/response/FollowResponse.java
+++ b/src/main/java/com/example/spartanewsfeed/follow/dto/response/FollowResponse.java
@@ -1,0 +1,12 @@
+package com.example.spartanewsfeed.follow.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class FollowResponse {
+    private final String message;
+
+    public FollowResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/spartanewsfeed/follow/dto/response/responseDto.java
+++ b/src/main/java/com/example/spartanewsfeed/follow/dto/response/responseDto.java
@@ -1,6 +1,0 @@
-package com.example.spartanewsfeed.follow.dto.response;
-
-// TODO : ("패키지 소실을 막기 위한 파일입니다.")
-
-public class responseDto {
-}

--- a/src/main/java/com/example/spartanewsfeed/follow/service/FollowService.java
+++ b/src/main/java/com/example/spartanewsfeed/follow/service/FollowService.java
@@ -3,31 +3,48 @@ package com.example.spartanewsfeed.follow.service;
 import com.example.spartanewsfeed.follow.entity.Follow;
 import com.example.spartanewsfeed.follow.repository.FollowRepository;
 import com.example.spartanewsfeed.user.entity.User;
+import com.example.spartanewsfeed.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class FollowService {
 
     private final FollowRepository followRepository;
+    private final UserRepository userRepository;
 
-    public FollowService(FollowRepository followRepository) {
-        this.followRepository = followRepository;
-    }
+    public void followUser(Long followerId, Long followingId) {
+        if (followerId.equals(followingId)) {
+            throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
+        }
 
-    public void followUser(User follower, User following) {
-        Optional<Follow> existingFollow = followRepository.findByFollowerAndFollowing(follower,following);
+        User follower = userRepository.findById(followerId).orElseThrow(
+                () -> new IllegalArgumentException("팔로우하는 사용자를 찾을 수 없습니다.")
+        );
+        User following = userRepository.findById(followingId).orElseThrow(
+                () -> new IllegalArgumentException("팔로우 대상 사용자를 찾을 수 없습니다.")
+        );
+
+        Optional<Follow> existingFollow = followRepository.findByFollowerAndFollowing(follower, following);
         if (existingFollow.isPresent()) {
             throw new IllegalArgumentException("이미 팔로우 되어있는 대상입니다.");
         }
-        Follow follow = new Follow(follower,following);
+        Follow follow = new Follow(follower, following);
         followRepository.save(follow);
     }
 
-    public void unfollowUser(User follower, User following) {
+    public void unfollowUser(Long followerId, Long followingId) {
+        User follower = userRepository.findById(followerId).orElseThrow(
+                () -> new IllegalArgumentException("언팔로우하는 사용자를 찾을 수 없습니다.")
+        );
+        User following = userRepository.findById(followingId).orElseThrow(
+                () -> new IllegalArgumentException("언팔로우 대상 사용자를 찾을 수 없습니다.")
+        );
         Follow followToDelete = followRepository.findByFollowerAndFollowing(follower, following).orElseThrow(
                 () -> new IllegalArgumentException("팔로우 되어있지 않은 대상입니다."));
         followRepository.delete(followToDelete);


### PR DESCRIPTION
프로젝트의 세션 기반 인증 방식을 사용하여, 로그인한 사용자 본인만 기능을 실행할 수 있도록 보안을 적용했습니다.
FollowController의 계층 구조를 개선하고, FollowResponse dto를 사용하도록 응답 형식을 통일했습니다.
requestdto 파일을 삭제했습니다